### PR TITLE
Remove C++ compilation dependencies from base

### DIFF
--- a/Dockerfile.alpine-base
+++ b/Dockerfile.alpine-base
@@ -6,9 +6,3 @@ RUN apk -U add \
     git \
     make \
     openssl
-
-RUN apk -U add \
-    expat-dev \
-    gcc \
-    g++ \
-    libstdc++

--- a/Dockerfile.elixir
+++ b/Dockerfile.elixir
@@ -1,4 +1,4 @@
-FROM operable/alpine-base:0.2
+FROM operable/alpine-base:0.3
 
 ENV ERLANG_PACKAGE_VERSION 18.3.2-r0
 ENV ELIXIR_VERSION 1.3.1

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: base elixir go
 
 base:
-	docker build -t operable/alpine-base:0.2 . -f Dockerfile.alpine-base
+	docker build -t operable/alpine-base:0.3 . -f Dockerfile.alpine-base
 
 elixir:
-	docker build -t operable/elixir:1.3.1-r3 . -f Dockerfile.elixir
+	docker build -t operable/elixir:1.3.1-r4 . -f Dockerfile.elixir
 
 go:
 	docker build -t operable/go:1.6.3-r1 . -f Dockerfile.go


### PR DESCRIPTION
These are currently needed only for compiling Greenbar. However, they take up about 150MB of space. Due to the nature of Docker's layering system, that means that we'll need to carry that around for all images that depend on our base! This almost doubles the size of our production Cog image, which is unacceptable.

Since we don't care so much about size for testing images, we can simply add the relevant package additions when we need them for tests.
