### PR TITLE
Upgrade to Erlang 19.1, Elixir 1.3.4

### DIFF
--- a/Dockerfile.elixir
+++ b/Dockerfile.elixir
@@ -1,23 +1,68 @@
 FROM operable/alpine-base:0.3
 
-ENV ERLANG_PACKAGE_VERSION 18.3.2-r0
-ENV ELIXIR_VERSION 1.3.1
+ENV ERLANG_VERSION 19.1
+ENV ELIXIR_VERSION 1.3.4
 
 # Erlang
-RUN apk -U add \
-    erlang=$ERLANG_PACKAGE_VERSION \
-    erlang-asn1=$ERLANG_PACKAGE_VERSION \
-    erlang-crypto=$ERLANG_PACKAGE_VERSION \
-    erlang-dev=$ERLANG_PACKAGE_VERSION \
-    erlang-erl-interface=$ERLANG_PACKAGE_VERSION \
-    erlang-inets=$ERLANG_PACKAGE_VERSION \
-    erlang-mnesia=$ERLANG_PACKAGE_VERSION \
-    erlang-parsetools=$ERLANG_PACKAGE_VERSION \
-    erlang-public-key=$ERLANG_PACKAGE_VERSION \
-    erlang-ssl=$ERLANG_PACKAGE_VERSION \
-    erlang-syntax-tools=$ERLANG_PACKAGE_VERSION \
-    erlang-tools=$ERLANG_PACKAGE_VERSION \
-    erlang-xmerl=$ERLANG_PACKAGE_VERSION
+#
+# Modified from
+# https://github.com/bitwalker/alpine-erlang
+WORKDIR /tmp/erlang-build
+RUN \
+    # Install Erlang/OTP deps
+    apk -U add \
+      openssl-dev \
+      ncurses-dev \
+      unixodbc-dev \
+      zlib-dev && \
+    # Install Erlang/OTP build deps
+    apk -U add --virtual .erlang-build \
+      build-base \
+      perl-dev && \
+    export ERLANG_SOURCE=otp_src_$ERLANG_VERSION && \
+    wget http://erlang.org/download/$ERLANG_SOURCE.tar.gz && \
+    tar -xzf $ERLANG_SOURCE.tar.gz && \
+    cd $ERLANG_SOURCE && \
+    export ERL_TOP=/tmp/erlang-build/$ERLANG_SOURCE && \
+    export PATH=$ERL_TOP/bin:$PATH && \
+    export CPPFlAGS="-D_BSD_SOURCE $CPPFLAGS" && \
+    # Configure
+    ./configure --prefix=/usr \
+      --without-javac \
+      --without-wx \
+      --without-debugger \
+      --without-observer \
+      --without-jinterface \
+      --without-common_test \
+      --without-cosEvent\
+      --without-cosEventDomain \
+      --without-cosFileTransfer \
+      --without-cosNotification \
+      --without-cosProperty \
+      --without-cosTime \
+      --without-cosTransactions \
+      --without-dialyzer \
+      --without-et \
+      --without-gs \
+      --without-ic \
+      --without-megaco \
+      --without-orber \
+      --without-percept \
+      --without-typer \
+      --enable-threads \
+      --enable-shared-zlib \
+      --enable-ssl=dynamic-ssl-lib \
+      --enable-hipe && \
+    # Build
+    make -j4 && make install && \
+    # Cleanup
+    apk del .erlang-build && \
+    rm -rf /tmp/erlang-build && \
+    # Remove Erlang source code
+    find /usr/lib/erlang/lib/* -type d -name src | xargs -n1 rm -Rf && \
+    rm -rf /var/cache/apk/*
+
+WORKDIR /
 
 # Elixir
 RUN wget https://github.com/elixir-lang/elixir/releases/download/v$ELIXIR_VERSION/Precompiled.zip && \

--- a/Dockerfile.elixir-debian
+++ b/Dockerfile.elixir-debian
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
-ENV ERLANG_PACKAGE_VERSION 18.3
-ENV ELIXIR_VERSION 1.3.1
+ENV ERLANG_PACKAGE_VERSION 19.1
+ENV ELIXIR_VERSION 1.3.4
 
 # TODO: Could be in debian-base?
 RUN apt-get update && apt-get -y install wget unzip git make

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-all: base elixir go
+all: base elixir go elixir-debian
 
 base:
 	docker build -t operable/alpine-base:0.3 . -f Dockerfile.alpine-base
 
 elixir:
-	docker build -t operable/elixir:1.3.1-r4 . -f Dockerfile.elixir
+	docker build -t operable/elixir:1.3.4-r0 . -f Dockerfile.elixir
 
 go:
 	docker build -t operable/go:1.6.3-r1 . -f Dockerfile.go
 
 elixir-debian:
-	docker build -t operable/elixir-debian:1.3.1-r0 . -f Dockerfile.elixir-debian
+	docker build -t operable/elixir-debian:1.3.4-r0 . -f Dockerfile.elixir-debian


### PR DESCRIPTION
We've had to build Erlang from source for the Alpine build because there
are no 19.1 packages available right now. Once they do become available,
we can revert back to using them.

Unfortunately, this adds about 50MB to the overall image size, despite
best efforts to minimize it.